### PR TITLE
Fix Arch Linux package names

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -59,7 +59,7 @@ To also install the newly built application, use `--create-debian-package` or `-
 
 ### Arch
 
-* `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2 libX11-devel libxkbfile-devel`
+* `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2 libx11 libxkbfile`
 * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware


### PR DESCRIPTION
Arch Linux does not have `devel` packages. There is neither `libX11-devel`, nor
`libxkbfile-devel`. They should be changed to `libx11` and `libxkbfile`.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
