### PR TITLE
Allow custom directory search providers to also override replace

### DIFF
--- a/spec/default-directory-searcher-spec.coffee
+++ b/spec/default-directory-searcher-spec.coffee
@@ -1,3 +1,6 @@
+fs = require 'fs-plus'
+path = require('path')
+temp = require('temp').track()
 DefaultDirectorySearcher = require '../src/default-directory-searcher'
 Task = require '../src/task'
 path = require 'path'
@@ -26,3 +29,19 @@ describe "DefaultDirectorySearcher", ->
 
     runs ->
       expect(Task::terminate).toHaveBeenCalled()
+
+  it "is able to replace files", ->
+    tempDir = temp.mkdirSync('dir')
+    tempFile = path.join(tempDir, 'test_file')
+    fs.writeFileSync(tempFile, 'aaa')
+
+    results = []
+    waitsForPromise ->
+      searcher.replace [tempFile], /a/, 'b', (result) ->
+        results.push(result)
+
+    runs ->
+      expect(results).toEqual [
+        {filePath: tempFile, replacements: 3},
+      ]
+      expect(fs.readFileSync(tempFile, 'utf8')).toBe 'bbb'

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -89,3 +89,25 @@ class DefaultDirectorySearcher
         isCancelled = true
         directorySearch.cancel()
     }
+
+  # Performs a replace across all the specified files.
+  #
+  # * `filePaths` An {Array} of file path strings to run the replace on.
+  # * `regex` A {RegExp} to search with.
+  # * `replacementText` {String} to replace all matches of regex with.
+  # * `iterator` A {Function} callback on each file with replacements:
+  #   * `options` {Object} with keys:
+  #     * `filePath` {String} a path with replacements
+  #     * `replacements` {Number} the count of replacements performed
+  #
+  # Returns a {Promise}.
+  replace: (filePaths, regex, replacementText, iterator) ->
+    new Promise (resolve, reject) ->
+      flags = 'g'
+      flags += 'i' if regex.ignoreCase
+
+      task = Task.once require.resolve('./replace-handler'),
+        filePaths, regex.source, flags, replacementText, resolve
+
+      task.on 'replace:path-replaced', iterator
+      task.on 'replace:file-error', (error) -> iterator(null, error)


### PR DESCRIPTION
This change allows providers of `atom.directory-searcher` to provide a
custom `replace` handler to override the default `scandal` replace, and
moves the existing replacement logic into the default `DirectorySearch`
provider.

For example, in Nuclide, we provide a custom directory searcher to
enable searching remote files. However, remote file replacement is still
broken.

As a temporary workaround we ended up monkey-patching
`atom.workspace.replace` (cc @zertosh):
https://github.com/facebook/nuclide/blob/master/pkg/nuclide-remote-projects/lib/patchAtomWorkspaceReplace.js#L41

This will allow us to remove the hack and just modify our custom
directory searcher instead.

Released under CC0.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
