### PR TITLE
Changed "git-core" package to "git-all" to support "git submodule" co…

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -51,11 +51,11 @@ To also install the newly built application, use `--create-debian-package` or `-
 
 ### Fedora
 
-* `sudo dnf install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+* `sudo dnf install make gcc gcc-c++ glibc-devel git-all libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
 
 ### RHEL / CentOS
 
-* `sudo yum install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+* `sudo yum install make gcc gcc-c++ glibc-devel git-all libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
 
 ### Arch
 


### PR DESCRIPTION
…mmand

In Fedora, RHEL and CentOS git-core package doesn't support "git submodule" command, so the build script break, I changed to "git-all" to enable it.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
